### PR TITLE
replace deprecated raise with return

### DIFF
--- a/subvolume.py
+++ b/subvolume.py
@@ -489,7 +489,7 @@ def generate_extents(path,tree):
               yield header,path,tree
           os.close(fs.fd)
           del fs
-          raise StopIteration
+          return
 
 
 #parallelize parsing, return the data without order what is the best value for chunk size?


### PR DESCRIPTION
"raise StopIteration" got deprecated with PEP 479 and generates runtime errors in newer python versions.
replaced it with "return"